### PR TITLE
feat: Refresh Token 기반 액세스 토큰 갱신 기능 구현 (#77)

### DIFF
--- a/src/main/java/me/synn3r/jipsa/core/api/auth/controller/TokenRefreshController.java
+++ b/src/main/java/me/synn3r/jipsa/core/api/auth/controller/TokenRefreshController.java
@@ -1,0 +1,76 @@
+package me.synn3r.jipsa.core.api.auth.controller;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.synn3r.jipsa.core.api.auth.service.RefreshTokenService;
+import me.synn3r.jipsa.core.api.commons.domain.FailResponse;
+import me.synn3r.jipsa.core.global.component.security.jwt.JwtTokenProvider;
+import me.synn3r.jipsa.core.global.component.security.userdetails.DefaultUserDetails;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class TokenRefreshController {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String INVALID_REFRESH_TOKEN_MESSAGE_KEY = "security.error.InvalidRefreshToken";
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenService refreshTokenService;
+	private final UserDetailsService userDetailsService;
+	private final MessageSource messageSource;
+
+	@PostMapping("/refresh")
+	public ResponseEntity<?> refresh(
+		@RequestHeader(value = AUTHORIZATION_HEADER, required = false) String bearerToken) {
+
+		if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(BEARER_PREFIX)) {
+			return unauthorized();
+		}
+
+		String refreshToken = bearerToken.substring(BEARER_PREFIX.length());
+
+		if (!jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
+			return unauthorized();
+		}
+
+		String userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+		String tokenId = jwtTokenProvider.getTokenIdFromRefreshToken(refreshToken);
+
+		if (!refreshTokenService.validate(userId, tokenId)) {
+			return unauthorized();
+		}
+
+		DefaultUserDetails userDetails = (DefaultUserDetails)userDetailsService.loadUserByUsername(userId);
+
+		String newAccessToken = jwtTokenProvider.createAccessToken(userDetails);
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+		String newTokenId = jwtTokenProvider.getTokenIdFromRefreshToken(newRefreshToken);
+
+		refreshTokenService.save(userId, newTokenId);
+
+		return ResponseEntity.ok()
+			.header(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken)
+			.body(new TokenRefreshResponse(newRefreshToken));
+	}
+
+	private ResponseEntity<FailResponse> unauthorized() {
+		String message = messageSource.getMessage(INVALID_REFRESH_TOKEN_MESSAGE_KEY, null,
+			LocaleContextHolder.getLocale());
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(FailResponse.of(message));
+	}
+
+	public record TokenRefreshResponse(String refreshToken) {
+	}
+}

--- a/src/main/java/me/synn3r/jipsa/core/api/auth/service/RefreshTokenService.java
+++ b/src/main/java/me/synn3r/jipsa/core/api/auth/service/RefreshTokenService.java
@@ -1,0 +1,10 @@
+package me.synn3r.jipsa.core.api.auth.service;
+
+public interface RefreshTokenService {
+
+	void save(String userId, String tokenId);
+
+	boolean validate(String userId, String tokenId);
+
+	void delete(String userId);
+}

--- a/src/main/java/me/synn3r/jipsa/core/api/auth/service/impl/RedisRefreshTokenServiceImpl.java
+++ b/src/main/java/me/synn3r/jipsa/core/api/auth/service/impl/RedisRefreshTokenServiceImpl.java
@@ -1,0 +1,38 @@
+package me.synn3r.jipsa.core.api.auth.service.impl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.synn3r.jipsa.core.api.auth.service.RefreshTokenService;
+import me.synn3r.jipsa.core.global.config.security.JwtConfig;
+
+@Service
+@RequiredArgsConstructor
+public class RedisRefreshTokenServiceImpl implements RefreshTokenService {
+
+	private static final String KEY_PREFIX = "refresh_token:";
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final JwtConfig jwtConfig;
+
+	@Override
+	public void save(String userId, String tokenId) {
+		String key = KEY_PREFIX + userId;
+		redisTemplate.opsForValue().set(key, tokenId, jwtConfig.getRefreshTokenValidity(), TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public boolean validate(String userId, String tokenId) {
+		String key = KEY_PREFIX + userId;
+		Object storedTokenId = redisTemplate.opsForValue().get(key);
+		return tokenId.equals(storedTokenId);
+	}
+
+	@Override
+	public void delete(String userId) {
+		redisTemplate.delete(KEY_PREFIX + userId);
+	}
+}

--- a/src/main/java/me/synn3r/jipsa/core/global/component/security/handler/DefaultAuthenticationSuccessHandler.java
+++ b/src/main/java/me/synn3r/jipsa/core/global/component/security/handler/DefaultAuthenticationSuccessHandler.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import me.synn3r.jipsa.core.api.auth.service.RefreshTokenService;
 import me.synn3r.jipsa.core.global.component.security.jwt.JwtTokenProvider;
 import me.synn3r.jipsa.core.global.component.security.service.AuthenticationHistoryService;
 import me.synn3r.jipsa.core.global.component.security.userdetails.DefaultUserDetails;
@@ -29,6 +30,7 @@ public class DefaultAuthenticationSuccessHandler implements AuthenticationSucces
 	private static final String SUCCESS_MESSAGE_KEY = "security.success.Authentication";
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenService refreshTokenService;
 	private final AuthenticationHistoryService authenticationHistoryService;
 	private final ObjectMapper objectMapper;
 	private final MessageSource messageSource;
@@ -38,8 +40,13 @@ public class DefaultAuthenticationSuccessHandler implements AuthenticationSucces
 		Authentication authentication) throws IOException {
 
 		DefaultUserDetails userDetails = (DefaultUserDetails)authentication.getPrincipal();
+		String userId = userDetails.getUsername();
 
 		String accessToken = jwtTokenProvider.createAccessToken(userDetails);
+		String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+		String tokenId = jwtTokenProvider.getTokenIdFromRefreshToken(refreshToken);
+
+		refreshTokenService.save(userId, tokenId);
 
 		response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + accessToken);
 		response.setStatus(HttpStatus.OK.value());
@@ -47,12 +54,12 @@ public class DefaultAuthenticationSuccessHandler implements AuthenticationSucces
 		response.setCharacterEncoding(CHARACTER_ENCODING);
 
 		String message = messageSource.getMessage(SUCCESS_MESSAGE_KEY, null, LocaleContextHolder.getLocale());
-		AuthenticationSuccessResponse successResponse = new AuthenticationSuccessResponse(message);
+		AuthenticationSuccessResponse successResponse = new AuthenticationSuccessResponse(message, refreshToken);
 		objectMapper.writeValue(response.getWriter(), successResponse);
 
-		authenticationHistoryService.recordSuccess(userDetails.getUsername());
+		authenticationHistoryService.recordSuccess(userId);
 	}
 
-	public record AuthenticationSuccessResponse(String message) {
+	public record AuthenticationSuccessResponse(String message, String refreshToken) {
 	}
 }

--- a/src/main/java/me/synn3r/jipsa/core/global/component/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/me/synn3r/jipsa/core/global/component/security/jwt/JwtTokenProvider.java
@@ -143,6 +143,15 @@ public class JwtTokenProvider {
 		return false;
 	}
 
+	public boolean isRefreshToken(String token) {
+		try {
+			Claims claims = parseClaims(token);
+			return TOKEN_TYPE_REFRESH.equals(claims.get(CLAIM_TYPE, String.class));
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
 	public boolean validateProfileVerificationToken(String token) {
 		try {
 			Claims claims = parseClaims(token);

--- a/src/main/java/me/synn3r/jipsa/core/global/config/security/SecurityConfig.java
+++ b/src/main/java/me/synn3r/jipsa/core/global/config/security/SecurityConfig.java
@@ -105,6 +105,7 @@ public class SecurityConfig {
 	 * @see DefaultAuthenticationSuccessHandler 인증 성공 시 토큰 발급 핸들러
 	 */
 	private static final String LOGIN_URL = "/api/auth/login";
+	private static final String REFRESH_URL = "/api/auth/refresh";
 
 	/**
 	 * 회원 관련 API 엔드포인트 URL.
@@ -354,6 +355,7 @@ public class SecurityConfig {
 				.accessDeniedHandler(jwtAccessDeniedHandler))
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(LOGIN_URL).permitAll()
+				.requestMatchers(HttpMethod.POST, REFRESH_URL).permitAll()
 				.requestMatchers(HttpMethod.POST, MEMBERS_URL).permitAll()
 				.requestMatchers(HttpMethod.POST, VERIFY_EMAIL_URL, CHECK_EMAIL_CODE_URL).permitAll()
 				.requestMatchers(HttpMethod.POST, SIGN_UP_URL).permitAll()

--- a/src/main/resources/messages/security.properties
+++ b/src/main/resources/messages/security.properties
@@ -10,3 +10,4 @@ security.error.AuthenticationRequired=인증이 필요합니다.
 security.error.ProfileVerificationRequired=프로필 수정을 위해 비밀번호 확인이 필요합니다.
 security.login.notfound=비밀번호가 틀립니다.
 security.login.unknown=알 수 없는 오류입니다. 관리자에게 문의하세요.
+security.error.InvalidRefreshToken=유효하지 않은 Refresh Token입니다.

--- a/src/main/resources/messages/security_en.properties
+++ b/src/main/resources/messages/security_en.properties
@@ -10,3 +10,4 @@ security.error.AuthenticationRequired=Authentication is required.
 security.error.ProfileVerificationRequired=Password verification is required for profile modification.
 security.login.notfound=Incorrect password.
 security.login.unknown=An unknown error occurred. Please contact the administrator.
+security.error.InvalidRefreshToken=Invalid refresh token.

--- a/src/main/resources/messages/security_ja.properties
+++ b/src/main/resources/messages/security_ja.properties
@@ -10,3 +10,4 @@ security.error.AuthenticationRequired=認証が必要です。
 security.error.ProfileVerificationRequired=プロフィールの修正にはパスワード確認が必要です。
 security.login.notfound=パスワードが間違っています。
 security.login.unknown=不明なエラーが発生しました。管理者にお問い合わせください。
+security.error.InvalidRefreshToken=無効なリフレッシュトークンです。

--- a/src/main/resources/messages/security_zh.properties
+++ b/src/main/resources/messages/security_zh.properties
@@ -10,3 +10,4 @@ security.error.AuthenticationRequired=需要认证。
 security.error.ProfileVerificationRequired=修改个人资料需要密码确认。
 security.login.notfound=密码错误。
 security.login.unknown=发生未知错误。请联系管理员。
+security.error.InvalidRefreshToken=无效的刷新令牌。

--- a/src/test/java/me/synn3r/jipsa/core/api/auth/AuthTestSupport.java
+++ b/src/test/java/me/synn3r/jipsa/core/api/auth/AuthTestSupport.java
@@ -1,0 +1,36 @@
+package me.synn3r.jipsa.core.api.auth;
+
+import org.mockito.Mockito;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import me.synn3r.jipsa.core.global.component.security.enums.Role;
+import me.synn3r.jipsa.core.global.component.security.jwt.JwtTokenProvider;
+import me.synn3r.jipsa.core.global.component.security.userdetails.DefaultUserDetails;
+import me.synn3r.jipsa.core.global.config.security.JwtConfig;
+
+public abstract class AuthTestSupport {
+
+	protected static final String TEST_JWT_SECRET =
+		"mySecretKeyForJwtTokenGenerationThatIsAtLeast256BitsLong";
+	protected static final long TEST_ACCESS_TOKEN_VALIDITY = 1800000L;
+	protected static final long TEST_REFRESH_TOKEN_VALIDITY = 1209600000L;
+	protected static final long TEST_PROFILE_VERIFICATION_TOKEN_VALIDITY = 300000L;
+
+	protected JwtConfig getTestJwtConfig() {
+		JwtConfig jwtConfig = new JwtConfig();
+		jwtConfig.setSecret(TEST_JWT_SECRET);
+		jwtConfig.setAccessTokenValidity(TEST_ACCESS_TOKEN_VALIDITY);
+		jwtConfig.setRefreshTokenValidity(TEST_REFRESH_TOKEN_VALIDITY);
+		jwtConfig.setProfileVerificationTokenValidity(TEST_PROFILE_VERIFICATION_TOKEN_VALIDITY);
+		return jwtConfig;
+	}
+
+	protected JwtTokenProvider getTestJwtTokenProvider() {
+		UserDetailsService userDetailsService = Mockito.mock(UserDetailsService.class);
+		return new JwtTokenProvider(getTestJwtConfig(), userDetailsService);
+	}
+
+	protected DefaultUserDetails getMockUserDetails() {
+		return new DefaultUserDetails(1L, "testUser", "test@email.com", "테스트유저", "password", Role.NORMAL);
+	}
+}

--- a/src/test/java/me/synn3r/jipsa/core/api/auth/controller/TokenRefreshControllerTest.java
+++ b/src/test/java/me/synn3r/jipsa/core/api/auth/controller/TokenRefreshControllerTest.java
@@ -1,0 +1,138 @@
+package me.synn3r.jipsa.core.api.auth.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.web.servlet.MockMvc;
+
+import me.synn3r.jipsa.core.api.auth.AuthTestSupport;
+import me.synn3r.jipsa.core.api.auth.service.RefreshTokenService;
+import me.synn3r.jipsa.core.config.security.TestSecurityConfig;
+import me.synn3r.jipsa.core.global.component.security.jwt.JwtTokenProvider;
+import me.synn3r.jipsa.core.global.component.security.userdetails.DefaultUserDetails;
+
+@WebMvcTest(controllers = TokenRefreshController.class,
+	includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TestSecurityConfig.class))
+@Import(TestSecurityConfig.class)
+@DisplayName("토큰 갱신 컨트롤러 테스트")
+class TokenRefreshControllerTest extends AuthTestSupport {
+
+	private static final String REFRESH_URL = "/api/auth/refresh";
+	private static final String VALID_REFRESH_TOKEN = "valid.refresh.token";
+	private static final String NEW_ACCESS_TOKEN = "new.access.token";
+	private static final String NEW_REFRESH_TOKEN = "new.refresh.token";
+	private static final String NEW_TOKEN_ID = "new-token-id";
+	private static final String USER_ID = "testUser";
+	private static final String TOKEN_ID = "test-token-id";
+
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	@MockBean
+	private RefreshTokenService refreshTokenService;
+
+	@MockBean
+	private UserDetailsService userDetailsService;
+
+	@MockBean
+	private MessageSource messageSource;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("유효한 Refresh Token으로 갱신 시 200과 새 토큰들이 반환되어야 함")
+	void refreshSuccess() throws Exception {
+		DefaultUserDetails userDetails = getMockUserDetails();
+		stubValidRefreshScenario(userDetails);
+
+		mockMvc.perform(post(REFRESH_URL)
+				.header("Authorization", "Bearer " + VALID_REFRESH_TOKEN))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Authorization", "Bearer " + NEW_ACCESS_TOKEN))
+			.andExpect(jsonPath("$.refreshToken").value(NEW_REFRESH_TOKEN));
+
+		verify(refreshTokenService).save(USER_ID, NEW_TOKEN_ID);
+	}
+
+	@Test
+	@DisplayName("Authorization 헤더가 없으면 401을 반환해야 함")
+	void refreshWithoutAuthorizationHeader() throws Exception {
+		when(messageSource.getMessage(any(), any(), any())).thenReturn("유효하지 않은 Refresh Token입니다.");
+
+		mockMvc.perform(post(REFRESH_URL))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("Bearer 접두어가 없는 토큰이면 401을 반환해야 함")
+	void refreshWithoutBearerPrefix() throws Exception {
+		when(messageSource.getMessage(any(), any(), any())).thenReturn("유효하지 않은 Refresh Token입니다.");
+
+		mockMvc.perform(post(REFRESH_URL)
+				.header("Authorization", VALID_REFRESH_TOKEN))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("JWT 서명이 유효하지 않은 토큰이면 401을 반환해야 함")
+	void refreshWithInvalidJwtSignature() throws Exception {
+		when(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).thenReturn(false);
+		when(messageSource.getMessage(any(), any(), any())).thenReturn("유효하지 않은 Refresh Token입니다.");
+
+		mockMvc.perform(post(REFRESH_URL)
+				.header("Authorization", "Bearer " + VALID_REFRESH_TOKEN))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("Access Token을 Refresh Token 자리에 사용하면 401을 반환해야 함")
+	void refreshWithAccessToken() throws Exception {
+		when(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).thenReturn(true);
+		when(jwtTokenProvider.isRefreshToken(VALID_REFRESH_TOKEN)).thenReturn(false);
+		when(messageSource.getMessage(any(), any(), any())).thenReturn("유효하지 않은 Refresh Token입니다.");
+
+		mockMvc.perform(post(REFRESH_URL)
+				.header("Authorization", "Bearer " + VALID_REFRESH_TOKEN))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("Redis에 없는 tokenId이면 401을 반환해야 함 (이미 사용되었거나 탈취된 토큰)")
+	void refreshWithAlreadyUsedToken() throws Exception {
+		when(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).thenReturn(true);
+		when(jwtTokenProvider.isRefreshToken(VALID_REFRESH_TOKEN)).thenReturn(true);
+		when(jwtTokenProvider.getUserIdFromToken(VALID_REFRESH_TOKEN)).thenReturn(USER_ID);
+		when(jwtTokenProvider.getTokenIdFromRefreshToken(VALID_REFRESH_TOKEN)).thenReturn(TOKEN_ID);
+		when(refreshTokenService.validate(USER_ID, TOKEN_ID)).thenReturn(false);
+		when(messageSource.getMessage(any(), any(), any())).thenReturn("유효하지 않은 Refresh Token입니다.");
+
+		mockMvc.perform(post(REFRESH_URL)
+				.header("Authorization", "Bearer " + VALID_REFRESH_TOKEN))
+			.andExpect(status().isUnauthorized());
+	}
+
+	private void stubValidRefreshScenario(DefaultUserDetails userDetails) {
+		when(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).thenReturn(true);
+		when(jwtTokenProvider.isRefreshToken(VALID_REFRESH_TOKEN)).thenReturn(true);
+		when(jwtTokenProvider.getUserIdFromToken(VALID_REFRESH_TOKEN)).thenReturn(USER_ID);
+		when(jwtTokenProvider.getTokenIdFromRefreshToken(VALID_REFRESH_TOKEN)).thenReturn(TOKEN_ID);
+		when(refreshTokenService.validate(USER_ID, TOKEN_ID)).thenReturn(true);
+		when(userDetailsService.loadUserByUsername(USER_ID)).thenReturn(userDetails);
+		when(jwtTokenProvider.createAccessToken(userDetails)).thenReturn(NEW_ACCESS_TOKEN);
+		when(jwtTokenProvider.createRefreshToken(USER_ID)).thenReturn(NEW_REFRESH_TOKEN);
+		when(jwtTokenProvider.getTokenIdFromRefreshToken(NEW_REFRESH_TOKEN)).thenReturn(NEW_TOKEN_ID);
+	}
+}

--- a/src/test/java/me/synn3r/jipsa/core/api/auth/service/RedisRefreshTokenServiceImplTest.java
+++ b/src/test/java/me/synn3r/jipsa/core/api/auth/service/RedisRefreshTokenServiceImplTest.java
@@ -1,0 +1,86 @@
+package me.synn3r.jipsa.core.api.auth.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import me.synn3r.jipsa.core.api.auth.service.impl.RedisRefreshTokenServiceImpl;
+import me.synn3r.jipsa.core.global.config.security.JwtConfig;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Redis Refresh Token 서비스 테스트")
+class RedisRefreshTokenServiceImplTest {
+
+	private static final String USER_ID = "testUser";
+	private static final String TOKEN_ID = "test-token-id-uuid";
+	private static final String KEY_PREFIX = "refresh_token:";
+	private static final long TTL = 1209600000L;
+
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Mock
+	private ValueOperations<String, Object> valueOperations;
+
+	@Mock
+	private JwtConfig jwtConfig;
+
+	@InjectMocks
+	private RedisRefreshTokenServiceImpl refreshTokenService;
+
+	@Test
+	@DisplayName("save() 호출 시 Redis에 올바른 key와 TTL로 tokenId가 저장되어야 함")
+	void save() {
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(jwtConfig.getRefreshTokenValidity()).thenReturn(TTL);
+
+		refreshTokenService.save(USER_ID, TOKEN_ID);
+
+		verify(valueOperations).set(KEY_PREFIX + USER_ID, TOKEN_ID, TTL, TimeUnit.MILLISECONDS);
+	}
+
+	@Test
+	@DisplayName("validate() - Redis에 저장된 tokenId와 일치하면 true를 반환해야 함")
+	void validateSuccess() {
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(KEY_PREFIX + USER_ID)).thenReturn(TOKEN_ID);
+
+		assertTrue(refreshTokenService.validate(USER_ID, TOKEN_ID));
+	}
+
+	@Test
+	@DisplayName("validate() - Redis에 해당 userId의 key가 없으면 false를 반환해야 함")
+	void validateKeyNotFound() {
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(KEY_PREFIX + USER_ID)).thenReturn(null);
+
+		assertFalse(refreshTokenService.validate(USER_ID, TOKEN_ID));
+	}
+
+	@Test
+	@DisplayName("validate() - Redis에 저장된 tokenId와 불일치하면 false를 반환해야 함")
+	void validateTokenIdMismatch() {
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(KEY_PREFIX + USER_ID)).thenReturn("different-token-id");
+
+		assertFalse(refreshTokenService.validate(USER_ID, TOKEN_ID));
+	}
+
+	@Test
+	@DisplayName("delete() 호출 시 Redis에서 해당 userId의 key가 삭제되어야 함")
+	void delete() {
+		refreshTokenService.delete(USER_ID);
+
+		verify(redisTemplate).delete(KEY_PREFIX + USER_ID);
+	}
+}

--- a/src/test/java/me/synn3r/jipsa/core/global/component/security/handler/DefaultAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/me/synn3r/jipsa/core/global/component/security/handler/DefaultAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,129 @@
+package me.synn3r.jipsa.core.global.component.security.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.synn3r.jipsa.core.api.auth.AuthTestSupport;
+import me.synn3r.jipsa.core.api.auth.service.RefreshTokenService;
+import me.synn3r.jipsa.core.global.component.security.jwt.JwtTokenProvider;
+import me.synn3r.jipsa.core.global.component.security.service.AuthenticationHistoryService;
+import me.synn3r.jipsa.core.global.component.security.userdetails.DefaultUserDetails;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("인증 성공 핸들러 테스트")
+class DefaultAuthenticationSuccessHandlerTest extends AuthTestSupport {
+
+	private static final String ACCESS_TOKEN = "test.access.token";
+	private static final String REFRESH_TOKEN = "test.refresh.token";
+	private static final String TOKEN_ID = "test-token-id";
+	private static final String SUCCESS_MESSAGE = "인증이 완료되었습니다.";
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private RefreshTokenService refreshTokenService;
+
+	@Mock
+	private AuthenticationHistoryService authenticationHistoryService;
+
+	@Mock
+	private MessageSource messageSource;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private DefaultAuthenticationSuccessHandler handler;
+
+	@BeforeEach
+	void setUp() {
+		handler = new DefaultAuthenticationSuccessHandler(
+			jwtTokenProvider, refreshTokenService, authenticationHistoryService, objectMapper, messageSource);
+	}
+
+	@Test
+	@DisplayName("로그인 성공 시 Authorization 헤더에 Access Token이 포함되어야 함")
+	void onAuthenticationSuccessAccessTokenInHeader() throws IOException {
+		DefaultUserDetails userDetails = getMockUserDetails();
+		Authentication authentication = mockAuthentication(userDetails);
+		stubTokenCreation(userDetails);
+
+		MockHttpServletResponse response = performSuccess(authentication);
+
+		assertEquals("Bearer " + ACCESS_TOKEN, response.getHeader("Authorization"));
+	}
+
+	@Test
+	@DisplayName("로그인 성공 시 응답 body에 refreshToken이 포함되어야 함")
+	void onAuthenticationSuccessRefreshTokenInBody() throws IOException {
+		DefaultUserDetails userDetails = getMockUserDetails();
+		Authentication authentication = mockAuthentication(userDetails);
+		stubTokenCreation(userDetails);
+
+		MockHttpServletResponse response = performSuccess(authentication);
+
+		@SuppressWarnings("unchecked")
+		Map<String, String> body = objectMapper.readValue(response.getContentAsString(), Map.class);
+		assertEquals(REFRESH_TOKEN, body.get("refreshToken"));
+	}
+
+	@Test
+	@DisplayName("로그인 성공 시 Refresh Token의 tokenId가 Redis에 저장되어야 함")
+	void onAuthenticationSuccessRefreshTokenSavedToRedis() throws IOException {
+		DefaultUserDetails userDetails = getMockUserDetails();
+		Authentication authentication = mockAuthentication(userDetails);
+		stubTokenCreation(userDetails);
+
+		performSuccess(authentication);
+
+		verify(refreshTokenService).save(userDetails.getUsername(), TOKEN_ID);
+	}
+
+	@Test
+	@DisplayName("로그인 성공 시 접속 이력이 기록되어야 함")
+	void onAuthenticationSuccessRecordsHistory() throws IOException {
+		DefaultUserDetails userDetails = getMockUserDetails();
+		Authentication authentication = mockAuthentication(userDetails);
+		stubTokenCreation(userDetails);
+
+		performSuccess(authentication);
+
+		verify(authenticationHistoryService).recordSuccess(userDetails.getUsername());
+	}
+
+	private Authentication mockAuthentication(DefaultUserDetails userDetails) {
+		Authentication authentication = mock(Authentication.class);
+		when(authentication.getPrincipal()).thenReturn(userDetails);
+		return authentication;
+	}
+
+	private void stubTokenCreation(DefaultUserDetails userDetails) {
+		when(jwtTokenProvider.createAccessToken(userDetails)).thenReturn(ACCESS_TOKEN);
+		when(jwtTokenProvider.createRefreshToken(userDetails.getUsername())).thenReturn(REFRESH_TOKEN);
+		when(jwtTokenProvider.getTokenIdFromRefreshToken(REFRESH_TOKEN)).thenReturn(TOKEN_ID);
+		when(messageSource.getMessage(any(), any(), any())).thenReturn(SUCCESS_MESSAGE);
+	}
+
+	private MockHttpServletResponse performSuccess(Authentication authentication) throws IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		handler.onAuthenticationSuccess(request, response, authentication);
+		return response;
+	}
+}

--- a/src/test/java/me/synn3r/jipsa/core/global/component/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/me/synn3r/jipsa/core/global/component/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,50 @@
+package me.synn3r.jipsa.core.global.component.security.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import me.synn3r.jipsa.core.api.auth.AuthTestSupport;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtTokenProvider 테스트")
+class JwtTokenProviderTest extends AuthTestSupport {
+
+	@Mock
+	private UserDetailsService userDetailsService;
+
+	private JwtTokenProvider jwtTokenProvider;
+
+	@BeforeEach
+	void setUp() {
+		jwtTokenProvider = new JwtTokenProvider(getTestJwtConfig(), userDetailsService);
+	}
+
+	@Test
+	@DisplayName("createRefreshToken()으로 생성한 토큰은 isRefreshToken()이 true를 반환해야 함")
+	void isRefreshTokenWithRefreshToken() {
+		String refreshToken = jwtTokenProvider.createRefreshToken("testUser");
+
+		assertTrue(jwtTokenProvider.isRefreshToken(refreshToken));
+	}
+
+	@Test
+	@DisplayName("createAccessToken()으로 생성한 토큰은 isRefreshToken()이 false를 반환해야 함")
+	void isRefreshTokenWithAccessToken() {
+		String accessToken = jwtTokenProvider.createAccessToken(getMockUserDetails());
+
+		assertFalse(jwtTokenProvider.isRefreshToken(accessToken));
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 문자열은 isRefreshToken()이 false를 반환해야 함")
+	void isRefreshTokenWithInvalidString() {
+		assertFalse(jwtTokenProvider.isRefreshToken("invalid.token.string"));
+	}
+}


### PR DESCRIPTION
## 🔗 관련 이슈

#77

## 🐞 이슈 원인

`auth` 모듈 제거 시 `RefreshTokenRepository`, `TokenRefreshRequest`, 갱신 로직이 함께 삭제됨.
액세스 토큰 만료(30분) 후 재로그인만 가능한 상태로, 사용자 경험에 직접적인 영향을 줌.

## 🔧 변경 사항 / 처리 과정

**구현**
- `POST /api/auth/refresh` 엔드포인트 추가 (`TokenRefreshController`)
- `RefreshTokenService` 인터페이스 및 `RedisRefreshTokenServiceImpl` 구현
  - Redis key: `refresh_token:{userId}` → tokenId, TTL 14일
- `DefaultAuthenticationSuccessHandler` 수정: 로그인 성공 시 Refresh Token 생성 및 Redis 저장, 응답 body에 포함
- `JwtTokenProvider`: `isRefreshToken()` 메서드 추가
- `SecurityConfig`: `/api/auth/refresh` 공개 엔드포인트 추가
- security 다국어 메시지에 `InvalidRefreshToken` 항목 추가 (ko/en/ja/zh)

**Refresh Token Rotation 적용**
- 갱신 시 기존 tokenId를 무효화하고 새 tokenId를 Redis에 저장
- Redis에 없는 tokenId 요청 시 401 반환 (탈취 감지)

**테스트**
- `AuthTestSupport`: 공통 테스트 지원 클래스 추가
- `JwtTokenProviderTest`: `isRefreshToken()` 검증 (3개)
- `RedisRefreshTokenServiceImplTest`: save/validate/delete 검증 (5개)
- `DefaultAuthenticationSuccessHandlerTest`: 로그인 성공 시 토큰 발급 및 저장 검증 (4개)
- `TokenRefreshControllerTest`: 성공/실패 시나리오 검증 (6개)

## ✅ 테스트 결과

- [x] 신규 API 정상 응답 확인
- [x] 기존 테스트 케이스 통과 (`./gradlew test`)
- [x] 기타 테스트 완료

## 📸 스크린샷 / 기타 참고 사항

**로그인 응답 구조 변경**
```
# 로그인 성공
POST /api/auth/login
← Authorization: Bearer {accessToken}  (헤더)
← { "message": "...", "refreshToken": "..." }  (바디)

# 토큰 갱신
POST /api/auth/refresh
→ Authorization: Bearer {refreshToken}
← Authorization: Bearer {newAccessToken}  (헤더)
← { "refreshToken": "{newRefreshToken}" }  (바디)
```

## 🙏 리뷰어에게 하고 싶은 말

- Refresh Token Rotation 적용으로 갱신 시마다 새 Refresh Token이 발급됩니다. 클라이언트에서 매번 새 Refresh Token을 저장해야 하는 점을 확인 부탁드립니다.
- 로그인 응답 body에 `refreshToken` 필드가 추가되었습니다. 기존 클라이언트 코드에 영향이 없는지 확인 부탁드립니다.